### PR TITLE
feat: 잠금페이지에 편지 미리 열어보기 기능 구현

### DIFF
--- a/src/pages/LetterDetail.jsx
+++ b/src/pages/LetterDetail.jsx
@@ -50,11 +50,6 @@ export default function LetterDetail() {
             {/* 편지 본문 */}
             <div className="flex-1 px-6 pt-3 pb-6">
                 <div className="rounded-md shadow-sm border border-[#eee5da] p-4 bg-white">
-                    {/* 작성일 */}
-                    <p className="text-xs text-gray-400 mb-1">
-                        {letter.createdAt} 작성
-                    </p>
-
                     {/* 제목 */}
                     <h1 className="text-main text-xl font-bold mb-4">
                         {letter.title}
@@ -65,17 +60,22 @@ export default function LetterDetail() {
                         className="text-[14px] text-gray-700 leading-[22px] whitespace-pre-wrap rounded-md px-1 pb-5"
                         style={{
                             backgroundImage: `repeating-linear-gradient(
-                                to bottom,
-                                transparent 0px,
-                                transparent 21px,
-                                rgba(0, 0, 0, 0.08) 22px
-                            )`,
+                    to bottom,
+                    transparent 0px,
+                    transparent 21px,
+                    rgba(0, 0, 0, 0.2) 22px
+                )`,
                             backgroundPosition: "0 22px", // 밑줄 위치
                             backgroundSize: "100% 22px",
                         }}
                     >
                         {letter.content}
                     </div>
+
+                    {/* 작성일 */}
+                    <p className="text-xs text-gray-400 text-right mt-2">
+                        {letter.createdAt} 작성
+                    </p>
                 </div>
             </div>
 

--- a/src/pages/LetterLocked.jsx
+++ b/src/pages/LetterLocked.jsx
@@ -1,28 +1,52 @@
+import { useNavigate, useParams } from "react-router-dom";
 import Header from "../components/Header";
 import Layout from "../components/Layout";
-import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 
 export default function LetterLocked() {
     const { id } = useParams();
     const [letter, setLetter] = useState(null);
     const [remainingDays, setRemainingDays] = useState(null);
+    const navigate = useNavigate();
 
     useEffect(() => {
         const stored = JSON.parse(localStorage.getItem("letters")) || [];
         const found = stored.find((item) => item.id === Number(id));
-        setLetter(found);
 
-        if (found) {
-            const today = new Date(); // 오늘 날짜
-            const openDate = new Date(found.openAt); // 편지 열람일
-            const diffTime = openDate.getTime() - today.getTime(); // '편지 열람일 - 오늘 날짜' 계산
-            const daysLeft = Math.ceil(diffTime / (1000 * 60 * 60 * 24)); // 계산한 날짜를 일수로 바꾸기
-            setRemainingDays(daysLeft);
+        if (!found) return;
+
+        const today = new Date();
+        today.setHours(0, 0, 0, 0); // 오늘 날짜 기준을 00:00으로 고정
+        const openDate = new Date(found.openAt);
+        openDate.setHours(0, 0, 0, 0); // 열람일도 00:00으로 고정
+
+        // 열람일이 오늘이거나 이미 열람가능 편지일 경우 상세페이지로 이동
+        if (openDate <= today || found.isLock === false) {
+            navigate(`/letter/${id}`);
+            return;
         }
-    }, [id]);
+
+        // 남은 날짜 계산
+        const diffTime = openDate.getTime() - today.getTime();
+        const daysLeft = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+        setRemainingDays(daysLeft);
+
+        setLetter(found);
+    }, [id, navigate]);
 
     if (!letter) return null;
+
+    // 미리보기 핸들러
+    const handlePreview = () => {
+        const stored = JSON.parse(localStorage.getItem("letters")) || [];
+        const updated = stored.map((item) =>
+            item.id === Number(id) ? { ...item, isLock: false } : item
+        );
+        localStorage.setItem("letters", JSON.stringify(updated));
+
+        // replace 옵션 추가 -> 히스토리에서 잠금페이지 제거
+        navigate(`/letter/${id}`, { replace: true });
+    };
 
     return (
         <Layout>
@@ -30,7 +54,7 @@ export default function LetterLocked() {
 
             {/* 내용 */}
             <div className="flex flex-col items-center justify-center text-center mt-50 gap-5">
-                <div className="w-[80px] h-[80px] flex items-center justify-center border-2 border-main rounded-full mb-10 shadow-md">
+                <div className="w-[80px] h-[80px] flex items-center justify-center border-2 border-main rounded-full mb-5 shadow-md">
                     <img
                         src="/icons/lock.svg"
                         alt="잠금 아이콘"
@@ -42,6 +66,14 @@ export default function LetterLocked() {
                     <span className="font-semibold">{remainingDays}일 뒤</span>
                     에 열람할 수 있어요.
                 </p>
+
+                {/* 미리보기 버튼 */}
+                <button
+                    onClick={handlePreview}
+                    className="text-xs text-gray-400 underline hover:text-main transition"
+                >
+                    지금 미리 열어보기
+                </button>
             </div>
         </Layout>
     );


### PR DESCRIPTION
## ✅ 구현 내용
- 아직 잠금 상태인 편지에 미리 열어보기 기능 추가
- 미리보기 클릭 시 '잠금 중' -> '열람가능'으로 상태 변경하고, 상세페이지로 이동
- 편지 상세페이지의 작성일을 우측 하단으로 변경

## ‼️ 기타
- 해당 열람일이 됐을 때 편지가 자동으로 상세페이지로 이동하는지 테스트하기

## 🚀 반영 브랜치
feat/letter-preview ➡️ main